### PR TITLE
[Normative] Capture the HTML entity behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1149,7 +1149,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-grammar","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-string-characters":["_ref_0"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-string-characters","titleHTML":"JSX String Characters","number":"1.5.1"},{"type":"clause","id":"sec-HTMLCharacterReference","titleHTML":"HTML Character References","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-jsx-JSXString-SV","titleHTML":"Static Semantics: SV","number":"1.5.3.1"},{"type":"clause","id":"sec-jsx-JSXString","titleHTML":"JSX String Definition","number":"1.5.3"},{"type":"clause","id":"sec-jsx-string","titleHTML":"JSX Strings","number":"1.5"},{"type":"clause","id":"sec-jsx","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   font-size: 18px;
@@ -2414,7 +2414,7 @@ li.menu-search-result-term:before {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-grammar" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / February 24, 2022</h1><h1 class="title">JSX</h1>
+    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-string" title="JSX Strings"><span class="secnum">1.5</span> JSX Strings</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-string-characters" title="JSX String Characters"><span class="secnum">1.5.1</span> JSX String Characters</a></li><li><span class="item-toggle-none"></span><a href="#sec-HTMLCharacterReference" title="HTML Character References"><span class="secnum">1.5.2</span> HTML Character References</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-JSXString" title="JSX String Definition"><span class="secnum">1.5.3</span> JSX String Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-JSXString-SV" title="Static Semantics: SV"><span class="secnum">1.5.3.1</span> SS: SV</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / February 24, 2022</h1><h1 class="title">JSX</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
@@ -2447,7 +2447,7 @@ li.menu-search-result-term:before {
 </emu-intro>
 
 
-<emu-clause id="sec-jsx-grammar">
+<emu-clause id="sec-jsx">
   <h1><span class="secnum">1</span> JSX Definition</h1>
 
   <emu-clause id="sec-jsx-PrimaryExpression">
@@ -2611,23 +2611,23 @@ li.menu-search-result-term:before {
     <emu-rhs a="ylbqkuqt"><emu-nt>JSXElement</emu-nt></emu-rhs>
     <emu-rhs a="xcc8tnvu"><emu-nt>JSXFragment</emu-nt></emu-rhs>
 </emu-production>
-<emu-production name="JSXDoubleStringCharacters">
-    <emu-nt>JSXDoubleStringCharacters</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yodnvall">
+<emu-production name="JSXDoubleStringCharacters" type="lexical">
+    <emu-nt>JSXDoubleStringCharacters</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="yodnvall">
         <emu-nt>JSXDoubleStringCharacter</emu-nt>
         <emu-nt optional="">JSXDoubleStringCharacters<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXDoubleStringCharacter">
-    <emu-nt>JSXDoubleStringCharacter</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ha2dt7pv"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
+<emu-production name="JSXDoubleStringCharacter" type="lexical">
+    <emu-nt>JSXDoubleStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="nfdqsh-q"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
 </emu-production>
-<emu-production name="JSXSingleStringCharacters">
-    <emu-nt>JSXSingleStringCharacters</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xebljaxt">
+<emu-production name="JSXSingleStringCharacters" type="lexical">
+    <emu-nt>JSXSingleStringCharacters</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="xebljaxt">
         <emu-nt>JSXSingleStringCharacter</emu-nt>
         <emu-nt optional="">JSXSingleStringCharacters<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXSingleStringCharacter">
-    <emu-nt>JSXSingleStringCharacter</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-ejk7lqw"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
+<emu-production name="JSXSingleStringCharacter" type="lexical">
+    <emu-nt>JSXSingleStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="rqns83ga"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 </emu-grammar>
   </emu-clause>
@@ -2658,8 +2658,8 @@ li.menu-search-result-term:before {
         <emu-nt optional="">JSXText<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXTextCharacter">
-    <emu-nt>JSXTextCharacter</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="9cx_g9a9"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
+<emu-production name="JSXTextCharacter" type="lexical">
+    <emu-nt>JSXTextCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="r679bmul"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 <emu-production name="JSXChildExpression">
     <emu-nt>JSXChildExpression</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1px9pijq"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
@@ -2669,6 +2669,155 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar>
+  </emu-clause>
+
+  <emu-clause id="sec-jsx-string">
+    <h1><span class="secnum">1.5</span> JSX Strings</h1>
+
+
+    <emu-clause id="sec-jsx-string-characters">
+      <h1><span class="secnum">1.5.1</span> JSX String Characters</h1>
+
+      <p>Historically, string characters within <emu-nt>JSXAttributeValue</emu-nt> and <emu-nt>JSXText</emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier. We may revisit this decision in the future.</p>
+      
+      <h2>Syntax</h2>
+
+      <emu-grammar><emu-production name="JSXStringCharacter" type="lexical">
+    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="uudq6psd"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-nt>HTMLCharacterReference</emu-nt></emu-gmod></emu-rhs>
+</emu-production>
+</emu-grammar>
+    </emu-clause>
+
+    <emu-clause id="sec-HTMLCharacterReference">
+      <h1><span class="secnum">1.5.2</span> HTML Character References</h1>
+      <emu-note><span class="note">Note 1</span><div class="note-contents">
+      <p>HTML character references are defined in the <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML standard</a>.</p>
+      </div></emu-note>
+
+      <h2>Syntax</h2>
+
+      <emu-grammar><emu-production name="HTMLCharacterReference" type="lexical">
+    <emu-nt>HTMLCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="ldmyv8x1"><emu-nt>XHTMLDecimalCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="92udv0vg"><emu-nt>XHTMLHexCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="-rh6rgss"><emu-nt>XHTMLNamedCharacterReference</emu-nt></emu-rhs>
+</emu-production>
+<emu-production name="HTMLDecimalCharacterReference" type="lexical">
+    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+        <emu-gmod>but only if MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt> ≦ 0x10FFFF</emu-gmod>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+<emu-production name="HTMLHexCharacterReference" type="lexical">
+    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9cf0zze">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-t>x</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
+        <emu-gmod>but only if MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt> ≦ 0x10FFFF</emu-gmod>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+<emu-production name="HTMLNamedCharacterReference" type="lexical">
+    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+        <emu-t>&amp;</emu-t>
+        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+<emu-production name="HTMLNamedCharacterReferenceName" type="lexical">
+    <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="kmiuecgl"><emu-gprose>An implementations-defined list of names</emu-gprose></emu-rhs>
+</emu-production>
+</emu-grammar>
+
+      <emu-note><span class="note">Note 2</span><div class="note-contents"> 
+        <p>We recommend an implementation to choose the list from either the HTML4 standard or the living HTML standard:</p>
+        <ul>
+        <li>
+        The HTML4 standard defined <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">a list of 252 character entity references</a> . 
+        </li>
+        <li>
+        The living HTML standard defined <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">a list of 2231 named character references</a> since the HTML5 standard. It also claimed that <a href="https://github.com/whatwg/html/blob/main/FAQ.md#html-should-add-more-named-character-references">this list is static and will not be expanded or changed in the future</a> to reduce support burden for languages such as JSX.
+        </li>
+        </ul>
+        <p>
+          As the time of writing, both Babel and TypeScript supports only the 252 names defined in the HTML4 standard.
+        </p>
+      </div></emu-note>
+    </emu-clause>
+
+
+    <emu-clause id="sec-jsx-JSXString">
+      <h1><span class="secnum">1.5.3</span> JSX String Definition</h1>
+      <h2>Syntax</h2>
+      <emu-grammar><emu-production name="JSXString">
+    <emu-nt>JSXString</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a4zlsky9"><emu-nt>JSXDoubleStringCharacters</emu-nt></emu-rhs>
+    <emu-rhs a="mk2bi2rf"><emu-nt>JSXSingleStringCharacters</emu-nt></emu-rhs>
+    <emu-rhs a="iwpkswln"><emu-nt>JSXText</emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
+
+      <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
+        <h1><span class="secnum">1.5.3.1</span> Static Semantics: SV</h1>
+        <p>An implementation may convert <emu-nt>JSXString</emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt>JSXStringCharacter</emu-nt>:</p> 
+        <ul>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="JSXStringCharacter" type="lexical" collapsed="" class=" inline">
+    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt>.
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="HTMLDecimalCharacterReference" type="lexical" collapsed="" class=" inline">
+    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="HTMLHexCharacterReference" type="lexical" collapsed="" class=" inline">
+    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-t>x</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="HTMLNamedCharacterReference" type="lexical" collapsed="" class=" inline">
+    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+        <emu-t>&amp;</emu-t>
+        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> according the implementation-defined list of names.
+            </ins>
+          </li>
+        </ul>
+
+        <p>The exact approach to fulfill the extended sematics is <a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a>.</p>
+        <emu-note><span class="note">Note</span><div class="note-contents">
+            For example, at the time of writing, Babel implemented this in its <a href="https://github.com/babel/babel/blob/main/packages/babel-parser/src/plugins/jsx/index.js">JSX parser</a>, while TypeScript implemented it via a <a href="https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformers/jsx.ts">JSX transformer</a>.
+        </div></emu-note>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -43,7 +43,7 @@ render(dropdown);
 </emu-intro>
 
 
-<emu-clause id="sec-jsx-grammar">
+<emu-clause id="sec-jsx">
   <h1>JSX Definition</h1>
 
   <emu-clause id="sec-jsx-PrimaryExpression">
@@ -134,17 +134,17 @@ JSXAttributeValue :
   JSXElement
   JSXFragment
 
-JSXDoubleStringCharacters :
+JSXDoubleStringCharacters ::
   JSXDoubleStringCharacter JSXDoubleStringCharacters?
 
-JSXDoubleStringCharacter :
-  SourceCharacter but not `"`
+JSXDoubleStringCharacter ::
+  JSXStringCharacter but not `"`
 
-JSXSingleStringCharacters :
+JSXSingleStringCharacters ::
   JSXSingleStringCharacter JSXSingleStringCharacters?
 
-JSXSingleStringCharacter :
-  SourceCharacter but not `'`
+JSXSingleStringCharacter ::
+  JSXStringCharacter but not `'`
     </emu-grammar>
   </emu-clause>
 
@@ -165,14 +165,119 @@ JSXChild :
 JSXText :
   JSXTextCharacter JSXText?
 
-JSXTextCharacter :
-  SourceCharacter but not one of `{` or `<` or `>` or `}`
+JSXTextCharacter ::
+  JSXStringCharacter but not one of `{` or `<` or `>` or `}`
 
 JSXChildExpression :
   AssignmentExpression
   `...` AssignmentExpression
 
     </emu-grammar>
+  </emu-clause>
+
+  <emu-clause id="sec-jsx-string">
+    <h1>JSX Strings</h1>
+
+
+    <emu-clause id="sec-jsx-string-characters">
+      <h1>JSX String Characters</h1>
+
+      <p>Historically, string characters within |JSXAttributeValue| and |JSXText| are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference">HTML character references</emu-xref> to make copy-pasting between HTML and JSX easier. We may revisit this decision in the future.</p>
+      
+      <h2>Syntax</h2>
+
+      <emu-grammar>
+        JSXStringCharacter::
+          SourceCharacter but not one of HTMLCharacterReference
+      </emu-grammar>
+    </emu-clause>
+
+    <emu-clause id="sec-HTMLCharacterReference">
+      <h1>HTML Character References</h1>
+      <emu-note>
+      <p>HTML character references are defined in the <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML standard</a>.</p>
+      </emu-note>
+
+      <h2>Syntax</h2>
+
+      <emu-grammar>
+        HTMLCharacterReference::
+          XHTMLDecimalCharacterReference
+          XHTMLHexCharacterReference
+          XHTMLNamedCharacterReference
+
+        HTMLDecimalCharacterReference::
+          `&` `#` DecimalDigits [> but only if MV of |DecimalDigits| ≦ 0x10FFFF] `;`
+
+        HTMLHexCharacterReference::
+          `&` `#` `x` HexDigits [> but only if MV of |HexDigits| ≦ 0x10FFFF] `;`
+
+        HTMLNamedCharacterReference::
+          `&` HTMLNamedCharacterReferenceName `;`
+
+        HTMLNamedCharacterReferenceName::
+          > An implementations-defined list of names
+      </emu-grammar>
+
+      <emu-note> 
+        <p>We recommend an implementation to choose the list from either the HTML4 standard or the living HTML standard:</p>
+        <ul>
+        <li>
+        The HTML4 standard defined <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">a list of 252 character entity references</a> . 
+        </li>
+        <li>
+        The living HTML standard defined <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">a list of 2231 named character references</a> since the HTML5 standard. It also claimed that <a href="https://github.com/whatwg/html/blob/main/FAQ.md#html-should-add-more-named-character-references">this list is static and will not be expanded or changed in the future</a> to reduce support burden for languages such as JSX.
+        </li>
+        </ul>
+        <p>
+          As the time of writing, both Babel and TypeScript supports only the 252 names defined in the HTML4 standard.
+        </p>
+      </emu-note>
+    </emu-clause>
+
+
+    <emu-clause id="sec-jsx-JSXString">
+      <h1>JSX String Definition</h1>
+      <h2>Syntax</h2>
+      <emu-grammar>
+        JSXString :
+          JSXDoubleStringCharacters
+          JSXSingleStringCharacters
+          JSXText
+      </emu-grammar>
+
+      <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
+        <h1>Static Semantics: SV</h1>
+        <p>An implementation may convert |JSXString| into a ECMAScript String value. In order to do this, JSX extends the syntax-directed operation <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to |JSXStringCharacter|:</p> 
+        <ul>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar> JSXStringCharacter :: SourceCharacter </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by |SourceCharacter|.
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar> HTMLDecimalCharacterReference:: `&` `#` DecimalDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |DecimalDigits|
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar>HTMLHexCharacterReference:: `&` `#` `x` HexDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |HexDigits|
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar>HTMLNamedCharacterReference:: `&` HTMLNamedCharacterReferenceName `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by |HTMLNamedCharacterReferenceName| according the implementation-defined list of names.
+            </ins>
+          </li>
+        </ul>
+
+        <p>The exact approach to fulfill the extended sematics is <a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a>.</p>
+        <emu-note>
+            For example, at the time of writing, Babel implemented this in its <a href="https://github.com/babel/babel/blob/main/packages/babel-parser/src/plugins/jsx/index.js">JSX parser</a>, while TypeScript implemented it via a <a href="https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformers/jsx.ts">JSX transformer</a>.
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
Let's be faithful to the de-facto and capture the HTML semantics
to the spec. I haven't seen any practices specifying transipilers
via ECMA-262 so this was a bit challenging may seems foreign.

I ended up extending `Static Semantics: SV` to make it concise and
(hopefully) accurate enough. I think this is a cool hack ;)

- Introduced `JSXStringCharacter` and `JSXString`
- Fix #133 by using `::` to make problematic grammars lexcial

I intentionally making the set of supported HTML entities
implementation-defined to allow either HTML4 or HTML5 set but
this is open to discuss.

Close #126
Close #4